### PR TITLE
Utilize force_system_openssl for Company of Heroes 2.

### DIFF
--- a/data/231430-Company_of_Heroes_2/00-pre
+++ b/data/231430-Company_of_Heroes_2/00-pre
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+force_system_openssl CompanyOfHeroes2

--- a/data/231430-Company_of_Heroes_2/00-pre
+++ b/data/231430-Company_of_Heroes_2/00-pre
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-force_system_openssl CompanyOfHeroes2
+force_system_openssl CompanyOfHeroes2.sh


### PR DESCRIPTION
Implement force_system_openssl for Company of Heroes , according to #1.